### PR TITLE
feat: prevent indexing and improve tab filtering enum import

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,11 @@
 <script setup>
 import Header from './components/Header.vue'
+
+useHead({
+  meta: [
+    { name: 'robots', content: 'noindex, nofollow' },
+  ],
+})
 </script>
 
 <template>

--- a/composables/useFilteredTabs.ts
+++ b/composables/useFilteredTabs.ts
@@ -1,6 +1,7 @@
 import { computed } from 'vue'
 import { useRuntimeConfig } from '#imports'
 import tabs from '~/const/categoryTab'
+import { FaqCategory } from '~/utils/category.enum'
 
 export function useFilteredTabs() {
   const { public: { appEnv } } = useRuntimeConfig()


### PR DESCRIPTION
- Added 'noindex, nofollow' meta tag via useHead in app.vue to block search engine indexing
- Imported FaqCategory enum in useFilteredTabs.ts for better category filtering or typing